### PR TITLE
Add maxConcurrentRequests and requestDelay property

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -5,6 +5,10 @@ on:
       - main
   pull_request:
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   test-and-release:
     name: Run tests and release
@@ -16,7 +20,7 @@ jobs:
       - uses: pnpm/setup@v1
         name: Install Node.js and pnpm
         with:
-          cache: true
+          cache: github.ref != 'refs/heads/main'
           install: false
 
       - name: Install dependencies

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -6,12 +6,11 @@ on:
   pull_request:
 
 permissions:
-  id-token: write  # Required for OIDC
   contents: read
 
 jobs:
-  test-and-release:
-    name: Run tests and release
+  verify:
+    name: Verify
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,7 +19,7 @@ jobs:
       - uses: pnpm/setup@v1
         name: Install Node.js and pnpm
         with:
-          cache: github.ref != 'refs/heads/main'
+          cache: ${{ github.ref != 'refs/heads/main' }}
           install: false
 
       - name: Install dependencies
@@ -33,9 +32,35 @@ jobs:
         run: pnpm typecheck
       - name: Run build
         run: pnpm build
+
+  release:
+    name: Release
+    needs: verify
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for trusted publishing and npm provenance
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # semantic-release reads the tags and history to pick the version
+
+      - uses: pnpm/setup@v1
+        name: Install Node.js and pnpm
+        with:
+          cache: false
+          install: false
+
+      - name: Install dependencies
+        run: pnpm install
+      # The published package ships dist, so it has to be built in this job too
+      - name: Run build
+        run: pnpm build
       - name: Release
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm semantic-release

--- a/README.md
+++ b/README.md
@@ -78,21 +78,22 @@ The OpenLayers bundle expects the global `ol` build and the map instance in `con
 
 ## Configuration
 
-| Option            | Description                                                                                                                              |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `baseUrl`         | Base URL of the SensorThings API service.                                                                                                |
-| `queryObject`     | A query object or zoom-based array of `{ zoomLevel, query }` entries. Supported entity types are `Things` and `FeaturesOfInterest`.      |
-| `cluster`         | Enables clustering. Defaults to enabled when omitted.                                                                                    |
-| `clusterMin`      | Minimum feature count for a cluster to remain displayed.                                                                                 |
-| `cachingDuration` | Cache lifetime in seconds. A falsy value keeps cached data indefinitely.                                                                 |
-| `plot`            | Observation range used by the default popup: `{ startDate, offset?, endDate? }`.                                                         |
-| `markerStyle`     | Marker color string or function. Supported colors are `green`, `black`, `blue`, `grey`, `violet`, `orange`, `red`, `yellow`, and `gold`. |
-| `polygonStyle`    | Style for non-point spatial features.                                                                                                    |
-| `clusterStyle`    | Circle and polygon styles for clusters, or a function returning them.                                                                    |
-| `fetchOptions`    | Options passed to `fetch` for SensorThings requests.                                                                                     |
-| `queryParameters` | `Map<string, string>` appended to every generated request URL.                                                                           |
-| `mqtt`            | Enables MQTT updates when the browser MQTT client is available.                                                                          |
-| `map`             | Required by the OpenLayers bundle; ignored by Leaflet.                                                                                   |
+| Option                  | Description                                                                                                                              |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `baseUrl`               | Base URL of the SensorThings API service.                                                                                                |
+| `queryObject`           | A query object or zoom-based array of `{ zoomLevel, query }` entries. Supported entity types are `Things` and `FeaturesOfInterest`.      |
+| `cluster`               | Enables clustering. Defaults to enabled when omitted.                                                                                    |
+| `clusterMin`            | Minimum feature count for a cluster to remain displayed.                                                                                 |
+| `cachingDuration`       | Cache lifetime in seconds. A falsy value keeps cached data indefinitely.                                                                 |
+| `plot`                  | Observation range used by the default popup: `{ startDate, offset?, endDate? }`.                                                         |
+| `markerStyle`           | Marker color string or function. Supported colors are `green`, `black`, `blue`, `grey`, `violet`, `orange`, `red`, `yellow`, and `gold`. |
+| `polygonStyle`          | Style for non-point spatial features.                                                                                                    |
+| `clusterStyle`          | Circle and polygon styles for clusters, or a function returning them.                                                                    |
+| `fetchOptions`          | Options passed to `fetch` for SensorThings requests.                                                                                     |
+| `maxConcurrentRequests` | Maximum number of requests in flight at once. Defaults to 5.                                                                             |
+| `queryParameters`       | `Map<string, string>` appended to every generated request URL.                                                                           |
+| `mqtt`                  | Enables MQTT updates when the browser MQTT client is available.                                                                          |
+| `map`                   | Required by the OpenLayers bundle; ignored by Leaflet.                                                                                   |
 
 Callbacks are available for marker and cluster hover/click events, and for popup close events. A `markerClick` callback may return HTML for the popup. The default popup can request observations through the feature's generated data callbacks:
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The OpenLayers bundle expects the global `ol` build and the map instance in `con
 | `clusterStyle`          | Circle and polygon styles for clusters, or a function returning them.                                                                    |
 | `fetchOptions`          | Options passed to `fetch` for SensorThings requests.                                                                                     |
 | `maxConcurrentRequests` | Maximum number of requests in flight at once. Defaults to 5.                                                                             |
+| `debounceDuration`      | Milliseconds the map has to be still before its data is requested. Defaults to 200.                                                      |
 | `queryParameters`       | `Map<string, string>` appended to every generated request URL.                                                                           |
 | `mqtt`                  | Enables MQTT updates when the browser MQTT client is available.                                                                          |
 | `map`                   | Required by the OpenLayers bundle; ignored by Leaflet.                                                                                   |

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ The OpenLayers bundle expects the global `ol` build and the map instance in `con
 | `polygonStyle`          | Style for non-point spatial features.                                                                                                    |
 | `clusterStyle`          | Circle and polygon styles for clusters, or a function returning them.                                                                    |
 | `fetchOptions`          | Options passed to `fetch` for SensorThings requests.                                                                                     |
-| `maxConcurrentRequests` | Maximum number of requests in flight at once. Defaults to 5.                                                                             |
+| `maxConcurrentRequests` | Requests sent per `requestDelay`. Without a delay the requests are not limited. Defaults to 5.                                           |
+| `requestDelay`          | Milliseconds between two waves of requests. Each wave sends up to `maxConcurrentRequests`. Defaults to 0.                                |
 | `debounceDuration`      | Milliseconds the map has to be still before its data is requested. Defaults to 200.                                                      |
 | `queryParameters`       | `Map<string, string>` appended to every generated request URL.                                                                           |
 | `mqtt`                  | Enables MQTT updates when the browser MQTT client is available.                                                                          |

--- a/example/leaflet.html
+++ b/example/leaflet.html
@@ -46,6 +46,31 @@
         markerStyle: function (feature) {
           return "yellow";
         },
+        clusterStyle: {
+          circle: {
+            color: "#4338ca",
+            weight: 2,
+            opacity: 0.9,
+            fillColor: "#ffffff",
+            fillOpacity: 0.85,
+          },
+          polygon: {
+            default: {
+              color: "#6366f1",
+              weight: 1,
+              opacity: 0.45,
+              fillColor: "#6366f1",
+              fillOpacity: 0.1,
+            },
+            hover: {
+              color: "#4338ca",
+              weight: 2,
+              opacity: 0.95,
+              fillColor: "#6366f1",
+              fillOpacity: 0.25,
+            },
+          },
+        },
         cluster: true,
         // cachingDuration: 10,
         clusterMin: 5,

--- a/example/leaflet.html
+++ b/example/leaflet.html
@@ -46,6 +46,7 @@
         markerStyle: function (feature) {
           return "yellow";
         },
+
         clusterStyle: {
           circle: {
             color: "#4338ca",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     ]
   },
   "scripts": {
-    "build": "pnpm tsdown",
+    "build": "pnpm tsdown --minify",
     "dev": "node scripts/dev.mjs",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
@@ -52,6 +52,7 @@
     "@types/leaflet": "^1.9.22",
     "all-contributors-cli": "^6.26.1",
     "events": "^3.3.0",
+    "p-limit": "^7.3.1",
     "picomodal": "^3.0.0",
     "prettier": "3.8.3",
     "semantic-release": "^25.0.9",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/leaflet": "^1.9.22",
     "all-contributors-cli": "^6.26.1",
     "events": "^3.3.0",
-    "p-limit": "^7.3.1",
+    "p-throttle": "^8.1.0",
     "picomodal": "^3.0.0",
     "prettier": "3.8.3",
     "semantic-release": "^25.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,9 +128,9 @@ importers:
       events:
         specifier: ^3.3.0
         version: 3.3.0
-      p-limit:
-        specifier: ^7.3.1
-        version: 7.3.1
+      p-throttle:
+        specifier: ^8.1.0
+        version: 8.1.0
       picomodal:
         specifier: ^3.0.0
         version: 3.0.0
@@ -1791,10 +1791,6 @@ packages:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
 
-  p-limit@7.3.1:
-    resolution: {integrity: sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==}
-    engines: {node: '>=20'}
-
   p-locate@2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
     engines: {node: '>=4'}
@@ -1810,6 +1806,10 @@ packages:
   p-reduce@3.0.0:
     resolution: {integrity: sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==}
     engines: {node: '>=12'}
+
+  p-throttle@8.1.0:
+    resolution: {integrity: sha512-c1wmXavsHZIC4g1OLhOsafK6jZSAeMo0Ap3yivj59PUcCkpacy5YgWdgIp/dB4vp1JZrfBSsPCR0YuADB+ENLQ==}
+    engines: {node: '>=20'}
 
   p-timeout@6.1.4:
     resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
@@ -2620,10 +2620,6 @@ packages:
   yargs@18.1.0:
     resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yocto-queue@1.2.2:
-    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
-    engines: {node: '>=12.20'}
 
   yoctocolors@2.2.0:
     resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
@@ -4037,10 +4033,6 @@ snapshots:
     dependencies:
       p-try: 2.2.0
 
-  p-limit@7.3.1:
-    dependencies:
-      yocto-queue: 1.2.2
-
   p-locate@2.0.0:
     dependencies:
       p-limit: 1.3.0
@@ -4052,6 +4044,8 @@ snapshots:
   p-map@7.0.6: {}
 
   p-reduce@3.0.0: {}
+
+  p-throttle@8.1.0: {}
 
   p-timeout@6.1.4: {}
 
@@ -4811,8 +4805,6 @@ snapshots:
       string-width: 8.2.2
       y18n: 5.0.8
       yargs-parser: 22.0.0
-
-  yocto-queue@1.2.2: {}
 
   yoctocolors@2.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       events:
         specifier: ^3.3.0
         version: 3.3.0
+      p-limit:
+        specifier: ^7.3.1
+        version: 7.3.1
       picomodal:
         specifier: ^3.0.0
         version: 3.0.0
@@ -1788,6 +1791,10 @@ packages:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
 
+  p-limit@7.3.1:
+    resolution: {integrity: sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==}
+    engines: {node: '>=20'}
+
   p-locate@2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
     engines: {node: '>=4'}
@@ -2613,6 +2620,10 @@ packages:
   yargs@18.1.0:
     resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   yoctocolors@2.2.0:
     resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
@@ -4026,6 +4037,10 @@ snapshots:
     dependencies:
       p-try: 2.2.0
 
+  p-limit@7.3.1:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@2.0.0:
     dependencies:
       p-limit: 1.3.0
@@ -4796,6 +4811,8 @@ snapshots:
       string-width: 8.2.2
       y18n: 5.0.8
       yargs-parser: 22.0.0
+
+  yocto-queue@1.2.2: {}
 
   yoctocolors@2.2.0: {}
 

--- a/src/MapInterface.ts
+++ b/src/MapInterface.ts
@@ -249,7 +249,7 @@ export class MapInterface extends EventEmitter {
       this.loadLayerData.bind(this),
       this.config.debounceDuration ?? DEFAULT_DEBOUNCE_DURATION,
       zoom,
-      boundingBox
+      boundingBox,
     );
   }
 
@@ -301,8 +301,6 @@ export class MapInterface extends EventEmitter {
       lat: this.lat2tile(boundingBox[3], zoom),
       lng: this.long2tile(boundingBox[2], zoom),
     };
-
-    var recs: any = [];
 
     var promises: any = [];
 
@@ -368,7 +366,7 @@ export class MapInterface extends EventEmitter {
         //Check if polygon is cached
         if (!existing) {
           promises.push(
-            new Promise(async (resolve, reject) => {
+            (async () => {
               //Check if clustering is enabled
               if (this.clusterEnabled) {
                 //Get count for the polygon
@@ -383,38 +381,28 @@ export class MapInterface extends EventEmitter {
                     console.error("Failed to fetch data", e);
                   }
                 }
+                //Leave the polygon uncached, so the next map movement retries it
+                if (!data) return;
+
                 feature.properties.count = data["@iot.count"];
                 this.addToCache(zoom, feature);
               } else {
                 //Don't get the data if clustering is disabled
                 this.addToCache(zoom, feature, false);
               }
-              resolve(feature);
-            }),
+
+              //Load this polygon's markers right away, instead of waiting for the other polygons
+              if (feature.properties.count < this.clusterMin || !this.clusterEnabled) {
+                await this.getMarkers([feature.geometry.coordinates], zoom);
+              }
+            })(),
           );
         }
       }
     }
 
-    var counts = await Promise.all(promises);
-
-    //Push all features to the recs array
-    counts.forEach((feature: any) => {
-      recs.push(feature);
-    });
-
-    var toMarker: any = [];
-
-    //Iterate all polygons
-    recs.forEach((feature: any) => {
-      //Check if markers should be loaded
-      if (feature.properties.count < this.clusterMin || !this.clusterEnabled) {
-        toMarker.push(feature.geometry.coordinates);
-      }
-    });
-
-    //Load markers
-    await this.getMarkers(toMarker, zoom);
+    //Every polygon renders and loads its markers on its own, this only awaits the last one
+    await Promise.all(promises);
   }
 
   /**

--- a/src/MapInterface.ts
+++ b/src/MapInterface.ts
@@ -1,5 +1,5 @@
-import { Config, QueryObject, Range, RangeQuery } from "./types.js";
-import { STAInterface } from "./STAInterface.js";
+import { Config, QueryObject, Range, RangeQuery } from "./types";
+import { STAInterface } from "./STAInterface";
 import { EventEmitter } from "events";
 
 declare var mqtt: any;
@@ -9,7 +9,7 @@ const DEFAULT_CLUSTER_MIN = 5;
 
 export class MapInterface extends EventEmitter {
   config: Config;
-  api: STAInterface;
+  readonly api: STAInterface;
   client: any;
   lastZoom: number;
 

--- a/src/MapInterface.ts
+++ b/src/MapInterface.ts
@@ -7,6 +7,9 @@ declare var mqtt: any;
 //Used when the config does not specify a minimum cluster size
 const DEFAULT_CLUSTER_MIN = 5;
 
+//Milliseconds the map has to be still before the data is requested
+const DEFAULT_DEBOUNCE_DURATION = 200;
+
 export class MapInterface extends EventEmitter {
   config: Config;
   readonly api: STAInterface;
@@ -15,6 +18,9 @@ export class MapInterface extends EventEmitter {
 
   //Stores the cached geojson
   cache: Array<CacheObject>;
+
+  //Pending request of a map movement that has not settled yet
+  private debounceTimer: ReturnType<typeof setTimeout> | undefined;
 
   //Clustering is enabled unless it was explicitly disabled
   private get clusterEnabled(): boolean {
@@ -232,12 +238,27 @@ export class MapInterface extends EventEmitter {
    * Gets a GeoJSON from the current zoom level and bounding box, the fetched data is cached
    * @param zoom current zoom level
    * @param boundingBox map's bounding box
-   * @returns a GeoJSON with polygons as clusters with the property count as the count of things inside the cluster, but only if the things are points. If not the thing's location is returned.
    */
-  async getLayerData(zoom: number, boundingBox: Array<number>) {
-    //If all data is cached, no event would be emitted
+  getLayerData(zoom: number, boundingBox: Array<number>) {
+    //Render what is cached right away, only the requests are debounced
     this.emitChange(zoom);
 
+    //Drop the movement that was still pending, its bounding box is outdated
+    clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(
+      this.loadLayerData.bind(this),
+      this.config.debounceDuration ?? DEFAULT_DEBOUNCE_DURATION,
+      zoom,
+      boundingBox
+    );
+  }
+
+  /**
+   * Requests everything missing from the cache for the given zoom level and bounding box
+   * @param zoom current zoom level
+   * @param boundingBox map's bounding box
+   */
+  private async loadLayerData(zoom: number, boundingBox: Array<number>) {
     //Removing the reference to config.queryObject
     var correctedQuery: QueryObject = JSON.parse(JSON.stringify(this.getQuery(zoom)));
 

--- a/src/QueryGenerator.ts
+++ b/src/QueryGenerator.ts
@@ -1,4 +1,4 @@
-import { Config, QueryObject } from "./types.js";
+import { Config, QueryObject } from "./types";
 
 /**
  * Used for creating a link from a QueryObject

--- a/src/STAInterface.ts
+++ b/src/STAInterface.ts
@@ -1,9 +1,12 @@
-import pLimit, { type LimitFunction } from "p-limit";
+import pThrottle from "p-throttle";
 import type { Config, QueryObject } from "./types";
 import { QueryGenerator } from "./QueryGenerator";
 
 //Browsers allow about this many parallel connections per host
 const DEFAULT_MAX_CONCURRENT_REQUESTS = 5;
+
+//Requests are not spaced out unless the config asks for it
+const DEFAULT_REQUEST_DELAY = 0;
 
 /**
  * Used for querying a sensorthings server, that may return a next link
@@ -11,17 +14,27 @@ const DEFAULT_MAX_CONCURRENT_REQUESTS = 5;
 export class STAInterface {
   config: Config;
 
-  //Caps the requests this interface has in flight at once
-  private limit: LimitFunction;
+  //Sends at most maxConcurrentRequests per requestDelay
+  private request: (url: string, options?: RequestInit) => Promise<Response>;
 
   constructor(config: Config) {
     this.config = config;
-    this.limit = pLimit(config.maxConcurrentRequests ?? DEFAULT_MAX_CONCURRENT_REQUESTS);
+
+    const delay = config.requestDelay ?? DEFAULT_REQUEST_DELAY;
+    //Wrapped, because fetch throws when it is called detached from its global
+    const send = (url: string, options?: RequestInit) => fetch(url, options);
+
+    this.request = delay
+      ? pThrottle({
+          limit: config.maxConcurrentRequests ?? DEFAULT_MAX_CONCURRENT_REQUESTS,
+          interval: delay,
+        })(send)
+      : send;
   }
 
-  //Waits for a free slot before requesting
-  private fetchJson(url: string, options?: RequestInit): Promise<any> {
-    return this.limit(async () => (await fetch(url, options)).json());
+  //Waits for this request's place in the current wave
+  private async fetchJson(url: string, options?: RequestInit): Promise<any> {
+    return (await this.request(url, options)).json();
   }
 
   async getGeoJson(query: QueryObject): Promise<any> {

--- a/src/STAInterface.ts
+++ b/src/STAInterface.ts
@@ -1,16 +1,30 @@
-import type { Config, QueryObject } from "./types.js";
-import { QueryGenerator } from "./QueryGenerator.js";
+import pLimit, { type LimitFunction } from "p-limit";
+import type { Config, QueryObject } from "./types";
+import { QueryGenerator } from "./QueryGenerator";
+
+//Browsers allow about this many parallel connections per host
+const DEFAULT_MAX_CONCURRENT_REQUESTS = 5;
 
 /**
  * Used for querying a sensorthings server, that may return a next link
  */
 export class STAInterface {
   config: Config;
+
+  //Caps the requests this interface has in flight at once
+  private limit: LimitFunction;
+
   constructor(config: Config) {
     this.config = config;
+    this.limit = pLimit(config.maxConcurrentRequests ?? DEFAULT_MAX_CONCURRENT_REQUESTS);
   }
 
-  getGeoJson(query: QueryObject): Promise<any> {
+  //Waits for a free slot before requesting
+  private fetchJson(url: string, options?: RequestInit): Promise<any> {
+    return this.limit(async () => (await fetch(url, options)).json());
+  }
+
+  async getGeoJson(query: QueryObject): Promise<any> {
     var limit: number | undefined = query.top;
     //Only query the given top elements, if a top value is present
     if (query.top == undefined || query.top == null) {
@@ -20,39 +34,34 @@ export class STAInterface {
     //Clone
     query = JSON.parse(JSON.stringify(query));
 
-    return new Promise(async (resolve, reject) => {
-      try {
-        //Generate url
-        var url = `${this.config.baseUrl}/${new QueryGenerator(query, this.config).toString()}`;
-        //get data
-        var data = await (await fetch(url as any, this.config.fetchOptions)).json();
-        if (data.value[0] && data.value[0].dataArray) {
-          data.value = data.value[0];
-        }
-        var link = data["@iot.nextLink"];
+    //Generate url
+    var url = `${this.config.baseUrl}/${new QueryGenerator(query, this.config).toString()}`;
+    //get data
+    var data = await this.fetchJson(url, this.config.fetchOptions);
+    if (data.value[0] && data.value[0].dataArray) {
+      data.value = data.value[0];
+    }
+    var link = data["@iot.nextLink"];
 
-        //Get data as long as a next link is present
-        while (
-          link &&
-          (limit == undefined ||
-            (data.value.length && data.value.length < limit) ||
-            (data.value.dataArray && data.value.dataArray.length < limit))
-        ) {
-          var response = await (await fetch(link)).json();
+    //Get data as long as a next link is present
+    while (
+      link &&
+      (limit == undefined ||
+        (data.value.length && data.value.length < limit) ||
+        (data.value.dataArray && data.value.dataArray.length < limit))
+    ) {
+      var response = await this.fetchJson(link);
 
-          if (response.value[0] && response.value[0].dataArray) {
-            data.value.dataArray.push(...response.value[0].dataArray);
-          } else {
-            //Push data in existing value array
-            data.value.push(...response.value);
-          }
-          //Update next link
-          link = response["@iot.nextLink"];
-        }
-        resolve(data);
-      } catch (e) {
-        reject(e);
+      if (response.value[0] && response.value[0].dataArray) {
+        data.value.dataArray.push(...response.value[0].dataArray);
+      } else {
+        //Push data in existing value array
+        data.value.push(...response.value);
       }
-    });
+      //Update next link
+      link = response["@iot.nextLink"];
+    }
+
+    return data;
   }
 }

--- a/src/leaflet.ts
+++ b/src/leaflet.ts
@@ -1,9 +1,9 @@
 // @ts-ignore
-import { textToMarker } from "./leaflet/markers.js";
-import { MapInterface } from "./MapInterface.js";
-import "./leaflet/realtime.js";
-import type { Config, ClusterStyle } from "./types.js";
-import { addCss, addTransparentBackground, createDefaultPopup } from "./utils.js";
+import { textToMarker } from "./leaflet/markers";
+import { MapInterface } from "./MapInterface";
+import "./leaflet/realtime";
+import type { Config, ClusterStyle } from "./types";
+import { addCss, addTransparentBackground, createDefaultPopup } from "./utils";
 
 declare global {
   namespace L {

--- a/src/openlayers.ts
+++ b/src/openlayers.ts
@@ -1,9 +1,9 @@
-import { MapInterface } from "./MapInterface.js";
-import type { Config, Path, ClusterStyle } from "./types.js";
-import { addCss, createDefaultPopup } from "./utils.js";
-import type Map from "ol/Map.js";
-import type VectorLayer from "ol/layer/Vector.js";
-import type VectorSource from "ol/source/Vector.js";
+import { MapInterface } from "./MapInterface";
+import type { Config, Path, ClusterStyle } from "./types";
+import { addCss, createDefaultPopup } from "./utils";
+import type Map from "ol/Map";
+import type VectorLayer from "ol/layer/Vector";
+import type VectorSource from "ol/source/Vector";
 
 declare global {
   var ol: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,8 @@ export interface Config {
   map?: any;
   /** Options passed to `fetch` for every SensorThings request. */
   fetchOptions?: RequestInit;
+  /** Maximum number of requests in flight at once. Defaults to `5`. */
+  maxConcurrentRequests?: number;
   /** Additional query parameters appended to every generated request URL. */
   queryParameters?: Map<string, string>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,8 @@ export interface Config {
   fetchOptions?: RequestInit;
   /** Maximum number of requests in flight at once. Defaults to `5`. */
   maxConcurrentRequests?: number;
+  /** Milliseconds the map has to be still before its data is requested. Defaults to `200`. */
+  debounceDuration?: number;
   /** Additional query parameters appended to every generated request URL. */
   queryParameters?: Map<string, string>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,8 +113,10 @@ export interface Config {
   map?: any;
   /** Options passed to `fetch` for every SensorThings request. */
   fetchOptions?: RequestInit;
-  /** Maximum number of requests in flight at once. Defaults to `5`. */
+  /** Requests sent per `requestDelay`. Without a delay the requests are not limited. Defaults to `5`. */
   maxConcurrentRequests?: number;
+  /** Milliseconds between two waves of `maxConcurrentRequests` requests. Defaults to `0`. */
+  requestDelay?: number;
   /** Milliseconds the map has to be still before its data is requested. Defaults to `200`. */
   debounceDuration?: number;
   /** Additional query parameters appended to every generated request URL. */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 //@ts-ignore
 import picoModal from "picomodal";
-import type { Config, Path, QueryObject } from "./types.js";
+import type { Config, Path, QueryObject } from "./types";
 
 declare var Plotly: any;
 

--- a/tests/MapInterface.test.ts
+++ b/tests/MapInterface.test.ts
@@ -56,4 +56,29 @@ describe("MapInterface", () => {
 
     expect(load).toHaveBeenCalledTimes(2);
   });
+
+  it("loads a polygon's markers before the other polygons are counted", async () => {
+    let releaseSecondCount = () => {};
+    const secondCount = new Promise<void>((resolve) => (releaseSecondCount = resolve));
+    let requests = 0;
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      requests++;
+      //Hold one polygon's count open, the others resolve right away
+      if (requests == 2) await secondCount;
+      return new Response(JSON.stringify({ value: [], "@iot.count": 0 }));
+    });
+
+    const mapInterface = new MapInterface(config);
+    const getMarkers = vi.spyOn(mapInterface as any, "getMarkers").mockResolvedValue(undefined);
+
+    const loaded = (mapInterface as any).loadLayerData(12, boundingBox);
+
+    //Markers are requested while the held count is still pending
+    await vi.waitFor(() => expect(getMarkers).toHaveBeenCalled());
+    expect(getMarkers.mock.calls[0][0]).toHaveLength(1);
+
+    releaseSecondCount();
+    await loaded;
+  });
 });

--- a/tests/MapInterface.test.ts
+++ b/tests/MapInterface.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MapInterface } from "../src/MapInterface.js";
+import type { Config } from "../src/types.js";
+
+const config: Config = {
+  baseUrl: "https://sensor.example/v1.1",
+  queryObject: { entityType: "Things" },
+  debounceDuration: 50,
+};
+
+//Bounding box as the map bundles report it: north east, then south west
+const boundingBox = [7.3, 50.3, 7.2, 50.2];
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("MapInterface", () => {
+  it("only requests the last movement while the map is still moving", async () => {
+    vi.useFakeTimers();
+    const mapInterface = new MapInterface(config);
+    const load = vi.spyOn(mapInterface as any, "loadLayerData").mockResolvedValue(undefined);
+
+    for (const zoom of [8, 9, 10, 11]) {
+      mapInterface.getLayerData(zoom, boundingBox);
+      await vi.advanceTimersByTimeAsync(10);
+    }
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(load).toHaveBeenCalledWith(11, boundingBox);
+  });
+
+  it("emits the cached features without waiting for the debounce", () => {
+    vi.useFakeTimers();
+    const mapInterface = new MapInterface(config);
+    vi.spyOn(mapInterface as any, "loadLayerData").mockResolvedValue(undefined);
+    const change = vi.fn();
+    mapInterface.on("change", change);
+
+    mapInterface.getLayerData(8, boundingBox);
+
+    expect(change).toHaveBeenCalledTimes(1);
+  });
+
+  it("requests again once the map settled", async () => {
+    vi.useFakeTimers();
+    const mapInterface = new MapInterface(config);
+    const load = vi.spyOn(mapInterface as any, "loadLayerData").mockResolvedValue(undefined);
+
+    mapInterface.getLayerData(8, boundingBox);
+    await vi.advanceTimersByTimeAsync(50);
+    mapInterface.getLayerData(9, boundingBox);
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/QueryGenerator.test.ts
+++ b/tests/QueryGenerator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { QueryGenerator } from "../src/QueryGenerator.js";
-import type { Config, QueryObject } from "../src/types.js";
+import { QueryGenerator } from "../src/QueryGenerator";
+import type { Config, QueryObject } from "../src/types";
 
 //A minimal configuration: only baseUrl and queryObject are required
 const config = (queryParameters?: Map<string, string>): Config => ({

--- a/tests/STAInterface.test.ts
+++ b/tests/STAInterface.test.ts
@@ -46,25 +46,6 @@ describe("STAInterface", () => {
     );
   });
 
-  it("never exceeds the configured request concurrency", async () => {
-    let inFlight = 0;
-    let peak = 0;
-    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
-      inFlight++;
-      peak = Math.max(peak, inFlight);
-      await new Promise((resolve) => setTimeout(resolve, 1));
-      inFlight--;
-      return new Response(JSON.stringify({ value: [{ id: 1 }] }));
-    });
-
-    const api = new STAInterface({ ...config, maxConcurrentRequests: 2 });
-    await Promise.all(
-      Array.from({ length: 10 }, (_, id) => api.getGeoJson({ entityType: "Things", id })),
-    );
-
-    expect(peak).toBe(2);
-  });
-
   it("merges dataArray pages", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
@@ -88,5 +69,26 @@ describe("STAInterface", () => {
       ["id", "time", 1],
       ["id", "time", 2],
     ]);
+  });
+
+  it("sends a full wave at once and delays only the next one", async () => {
+    const sentAt: number[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      sentAt.push(Date.now());
+      return new Response(JSON.stringify({ value: [{ id: 1 }] }));
+    });
+
+    const api = new STAInterface({ ...config, maxConcurrentRequests: 2, requestDelay: 30 });
+    await Promise.all(
+      Array.from({ length: 5 }, (_, id) => api.getGeoJson({ entityType: "Things", id })),
+    );
+
+    expect(sentAt).toHaveLength(5);
+    //Two per wave, the waves are 30ms apart. Timers may fire late, but never early
+    const elapsed = sentAt.map((at) => at - sentAt[0]);
+    expect(elapsed[1]).toBeLessThan(29);
+    expect(elapsed[2]).toBeGreaterThanOrEqual(29);
+    expect(elapsed[3] - elapsed[2]).toBeLessThan(29);
+    expect(elapsed[4]).toBeGreaterThanOrEqual(59);
   });
 });

--- a/tests/STAInterface.test.ts
+++ b/tests/STAInterface.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { STAInterface } from "../src/STAInterface.js";
-import type { Config, QueryObject } from "../src/types.js";
+import { STAInterface } from "../src/STAInterface";
+import type { Config, QueryObject } from "../src/types";
 
 const config: Config = {
   baseUrl: "https://sensor.example/v1.1",
@@ -38,7 +38,31 @@ describe("STAInterface", () => {
       "https://sensor.example/v1.1/Things?$top=3",
       undefined,
     );
-    expect(fetchMock).toHaveBeenNthCalledWith(2, "https://sensor.example/v1.1/Things?$skip=2");
+    //The next link is requested without the configured fetch options
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://sensor.example/v1.1/Things?$skip=2",
+      undefined,
+    );
+  });
+
+  it("never exceeds the configured request concurrency", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight--;
+      return new Response(JSON.stringify({ value: [{ id: 1 }] }));
+    });
+
+    const api = new STAInterface({ ...config, maxConcurrentRequests: 2 });
+    await Promise.all(
+      Array.from({ length: 10 }, (_, id) => api.getGeoJson({ entityType: "Things", id })),
+    );
+
+    expect(peak).toBe(2);
   });
 
   it("merges dataArray pages", async () => {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
   },
   platform: "browser",
   deps: {
+    onlyBundle: false,
     neverBundle: ["leaflet", "ol/*"],
   },
   sourcemap: true,
-  //minify: true,
 });


### PR DESCRIPTION
introduce maxConcurrentRequests to limit the number of concurrent requests made by the STAInterface. This change enhances performance and prevents overwhelming the server with too many simultaneous requests. Updated related code to utilize this new configuration option effectively.
